### PR TITLE
ID Adjustments

### DIFF
--- a/ROM.md
+++ b/ROM.md
@@ -7,10 +7,10 @@ ROM
 
 |     Item       |   Value    |   Comment
 | -------------: | ---------- | ----------------
-|    Vendor code | 0x0000     | TBD
-|      Device ID | 0x0000     | TBD
-|    Device type | 0x0000     | (TDB)
-|        Version | 1          | dicates size
+|    Vendor code |            | (Various)
+|      Device ID | 0x11F0     | 
+|    Device type | 0x11F0     | Integrated memory
+|        Version | 1          | dictates size
 
 Device Description
 ----

--- a/clock.md
+++ b/clock.md
@@ -8,8 +8,8 @@ Generic Clock
 |     Item       |   Value    |   Comment
 | -------------: | ---------- | ----------------
 |    Vendor code | 0x1c6c8b36 | NYA Elektriska
-|      Device ID | 0x12d0b402 | Generic Clock
-|    Device type | 0x0000     | (TDB)
+|      Device ID | 0x12d1b402 | Generic Clock
+|    Device type | 0x12d1     | Integrated Timer, generates HWI
 |        Version | 1          | Fixed Version
 
 Device Description

--- a/device-type.md
+++ b/device-type.md
@@ -29,9 +29,10 @@ All devices with the same hardware class and standard API ID can be used in the 
 
  * 0 - expansion buses
  * 1 - integrated devices
+   * 1 - on-board memory
    * 2 - timers
    * 3 - RNG
-   * 4 - real time clocks
+   * 4 - real time clocks 
  * 2 - sensors (input only devices)
  * 3 - human interfacing specific devices
    * 0 - keyboards


### PR DESCRIPTION
- Clock ID should reflect ability to cause HWI
- Gave ROM an ID
- Added on-board memory subtype
