### PR TITLE
Produced ID Tracker

### DIFF
--- a/TC-IDs.md
+++ b/TC-IDs.md
@@ -1,0 +1,39 @@
+# Currently used ID's:
+
+* `0x010C 337D` - Luxul
+  * `0x41F2 0003` - ver `0x002A` - [Photon Indicator - Luxul-pi.md](https://github.com/techcompliant/TC-Specs/blob/master/Luxul-pi.md)
+  
+* `0x1C6C 8B36` - Nya Elektriska
+  * `0x12D1 B402` - ver `0x0001` - [Generic Clock - clock.md](https://github.com/techcompliant/TC-Specs/blob/master/clock.md)
+  * `0x30CF 7406` - ver `0x0001` - [Generic Keyboard - keyboard.md](https://github.com/techcompliant/TC-Specs/blob/master/keyboard.md)
+  * `0x7349 F615` - ver `0x1802` - [Low Energy Monitor - LEM1802.txt](https://github.com/techcompliant/TC-Specs/blob/master/LEM1802.txt)
+  
+* `0x1EB3 7E91` - Mackapar Media
+  * `0x4AC5 525D` - ver `0x0001` - [Mackapar 5.25" Hard Disk Drive - m525hd.md](https://github.com/techcompliant/TC-Specs/blob/master/m525hd.md)
+  * `0x4FD5 24C5` - ver `0x000B` - [Mackapar 3.5" Floppy Drive - m35fd.txt](https://github.com/techcompliant/TC-Specs/blob/master/m35fd.txt)
+  
+* `0x59EA 5742` - Meisaka Engineering and Integration
+  * `0x70E3 E4FF` - ver `~     ` - [Embedded Display Controller - EDC.md](https://github.com/techcompliant/TC-Specs/blob/master/EDC.md)
+  
+* `0x982D 3E46` - Talon Navigation Systems
+  * `0xFCE2 4728` - ver `0xC59F` - [Local Positioning System - TalonNav-LPS.md](https://github.com/techcompliant/TC-Specs/blob/master/TalonNav-LPS.md)
+  * `0XFCE2 6509` - ver `0xB01E` - [Pulsar Positioning System - pps.txt](https://github.com/techcompliant/TC-Specs/blob/master/pps.md)
+  
+* `0xA87C 900E` - Kai Communications
+  * `0xD0F0 90C0` - ver `0x0001` - [Remote Activity Control Module - KaiComm-RACM.md](https://github.com/techcompliant/TC-Specs/blob/master/KaiComm-RACM.md)
+  * `0xE023 9088` - ver `~     ` - [Hardware Interface Card - KaiComm-HIC.md](https://github.com/techcompliant/TC-Specs/blob/master/KaiComm-HIC.md)
+  * `0xE57D 9027` - ver `0x0103` - [Synchronous Serial Interface - KaiComm-SSI.md](https://github.com/techcompliant/TC-Specs/blob/master/KaiComm-SSI.md)
+  
+* `0xB8BA DDE8` - Otec
+  * `0x3846 BC64` - ver `0x6673` - [FF32-EM Radar - radar.txt](https://github.com/techcompliant/TC-Specs/blob/master/radar.txt)
+  * `0x3846 BC64` - ver `0x6673` - [Tracking Theodolite TT-Z80 - tracking.txt](https://github.com/techcompliant/TC-Specs/blob/master/tracking.txt)
+  
+* `0xC220 0311` - Rin Yu Research
+  * `0xF7F7 EE03` - ver `0x0400` - [Vectored Thruster Array Control Interface - VTACI.md](https://github.com/techcompliant/TC-Specs/blob/master/VTACI.md)
+  
+* `~` - Various Vendors
+  * `0x11E0 DACC` - ver `0x0004` - [Integrated Activity Control Module - cpu-control.md](https://github.com/techcompliant/TC-Specs/blob/master/cpu-control.md)
+  * `0x48F0 EFFD` - ver `0x0001` - [ROM - ROM.md](https://github.com/techcompliant/TC-Specs/blob/master/ROM.md)
+  
+  
+# Devices with no ID:


### PR DESCRIPTION
Introduce Markdown-formatted document in order to prevent double-assignment of Device and Manufacturer IDs.  Links to documents in question included.  Tilde simply means "varying".
