### PR TITLE
Remove dupe ID

### DIFF
--- a/TC-IDs.md
+++ b/TC-IDs.md
@@ -10,9 +10,6 @@ Currently used IDs
   * `0x4AC5525D` - ver `0x0001` - [Mackapar 5.25" Hard Disk Drive](m525hd.md)
   * `0x4FD524C5` - ver `0x000B` - [Mackapar 3.5" Floppy Drive](m35fd.txt)
 
-* `0x59EA5742` - Meisaka Engineering and Integration
-  * `0x70E3E4FF` - ver `~     ` - [Embedded Display Controller](EDC.md)
-
 * `0x982D3E46` - Talon Navigation Systems
   * `0xFCE24728` - ver `0xC59F` - [Local Positioning System](TalonNav-LPS.md)
   * `0XFCE26509` - ver `0xB01E` - [Pulsar Positioning System](pps.txt)


### PR DESCRIPTION
Left the Meisaka EDC in the space above, despite moving it under Peripherals.
